### PR TITLE
Local dev improvements

### DIFF
--- a/amplify/backend/api/kiyanawapp/schema.graphql
+++ b/amplify/backend/api/kiyanawapp/schema.graphql
@@ -34,7 +34,7 @@ type Enquiry
   languageIndex: String!
   type: PhraseType!
   warriorId: ID!
-  warrior: Warrior @connection(fields: ["warriorId"])
+  warrior: Warrior! @connection(fields: ["warriorId"])
   warriorName: String!
   responses: [Response] @connection(keyName: "ByEnquiry", fields: ["id"])
   # this field is required to be able to sort on dates
@@ -66,9 +66,9 @@ type Response
   type: PhraseType!
   languageIndex: String!
   enquiryId: ID!
-  enquiry: Enquiry @connection(fields: ["enquiryId"])
+  enquiry: Enquiry! @connection(fields: ["enquiryId"])
   warriorId: ID!
-  warrior: Warrior @connection(fields: ["warriorId"])
+  warrior: Warrior! @connection(fields: ["warriorId"])
   warriorName: String!
   media: [Media] @connection(keyName: "ByResponse", fields: ["id"])
   # this field is required to be able to sort on dates
@@ -90,9 +90,9 @@ type Media
     ]
   ) {
   responseId: ID!
-  response: Response @connection(fields: ["responseId"])
+  response: Response! @connection(fields: ["responseId"])
   warriorId: ID!
-  warrior: Warrior @connection(fields: ["warriorId"])
+  warrior: Warrior! @connection(fields: ["warriorId"])
   warriorName: String!
   url: String!
 }

--- a/amplify/backend/api/kiyanawapp/schema.graphql
+++ b/amplify/backend/api/kiyanawapp/schema.graphql
@@ -35,7 +35,6 @@ type Enquiry
   type: PhraseType!
   warriorId: ID!
   warrior: Warrior! @connection(fields: ["warriorId"])
-  warriorName: String!
   responses: [Response] @connection(keyName: "ByEnquiry", fields: ["id"])
   # this field is required to be able to sort on dates
   table: EnquiryType!
@@ -69,7 +68,6 @@ type Response
   enquiry: Enquiry! @connection(fields: ["enquiryId"])
   warriorId: ID!
   warrior: Warrior! @connection(fields: ["warriorId"])
-  warriorName: String!
   media: [Media] @connection(keyName: "ByResponse", fields: ["id"])
   # this field is required to be able to sort on dates
   table: ResponseType!
@@ -93,7 +91,6 @@ type Media
   response: Response! @connection(fields: ["responseId"])
   warriorId: ID!
   warrior: Warrior! @connection(fields: ["warriorId"])
-  warriorName: String!
   url: String!
 }
 

--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -9,7 +9,7 @@ const entryFile = path.join(__dirname + "/../src/main.js");
 
 module.exports = function(options) {
   return {
-    devtool: "source-map",
+    devtool: "inline-source-map",
     mode: options.mode,
     entry: entryFile,
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2570,177 +2570,178 @@
       }
     },
     "@webassemblyjs/ast": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",
-      "integrity": "sha512-C6wW5L+b7ogSDVqymbkkvuW9kruN//YisMED04xzeBBqjHa2FYnmvOlS6Xj68xWQRgWvI9cIglsjFowH/RJyEA==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.8.5.tgz",
+      "integrity": "sha512-aJMfngIZ65+t71C3y2nBBg5FFG0Okt9m0XEgWZ7Ywgn1oMAT8cNwx00Uv1cQyHtidq0Xn94R4TAywO+LCQ+ZAQ==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/helper-module-context": "1.9.0",
-        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
-        "@webassemblyjs/wast-parser": "1.9.0"
+        "@webassemblyjs/helper-module-context": "1.8.5",
+        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+        "@webassemblyjs/wast-parser": "1.8.5"
       }
     },
     "@webassemblyjs/floating-point-hex-parser": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.9.0.tgz",
-      "integrity": "sha512-TG5qcFsS8QB4g4MhrxK5TqfdNe7Ey/7YL/xN+36rRjl/BlGE/NcBvJcqsRgCP6Z92mRE+7N50pRIi8SmKUbcQA==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.8.5.tgz",
+      "integrity": "sha512-9p+79WHru1oqBh9ewP9zW95E3XAo+90oth7S5Re3eQnECGq59ly1Ri5tsIipKGpiStHsUYmY3zMLqtk3gTcOtQ==",
       "dev": true
     },
     "@webassemblyjs/helper-api-error": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.9.0.tgz",
-      "integrity": "sha512-NcMLjoFMXpsASZFxJ5h2HZRcEhDkvnNFOAKneP5RbKRzaWJN36NC4jqQHKwStIhGXu5mUWlUUk7ygdtrO8lbmw==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.8.5.tgz",
+      "integrity": "sha512-Za/tnzsvnqdaSPOUXHyKJ2XI7PDX64kWtURyGiJJZKVEdFOsdKUCPTNEVFZq3zJ2R0G5wc2PZ5gvdTRFgm81zA==",
       "dev": true
     },
     "@webassemblyjs/helper-buffer": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.9.0.tgz",
-      "integrity": "sha512-qZol43oqhq6yBPx7YM3m9Bv7WMV9Eevj6kMi6InKOuZxhw+q9hOkvq5e/PpKSiLfyetpaBnogSbNCfBwyB00CA==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.8.5.tgz",
+      "integrity": "sha512-Ri2R8nOS0U6G49Q86goFIPNgjyl6+oE1abW1pS84BuhP1Qcr5JqMwRFT3Ah3ADDDYGEgGs1iyb1DGX+kAi/c/Q==",
       "dev": true
     },
     "@webassemblyjs/helper-code-frame": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.9.0.tgz",
-      "integrity": "sha512-ERCYdJBkD9Vu4vtjUYe8LZruWuNIToYq/ME22igL+2vj2dQ2OOujIZr3MEFvfEaqKoVqpsFKAGsRdBSBjrIvZA==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.8.5.tgz",
+      "integrity": "sha512-VQAadSubZIhNpH46IR3yWO4kZZjMxN1opDrzePLdVKAZ+DFjkGD/rf4v1jap744uPVU6yjL/smZbRIIJTOUnKQ==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/wast-printer": "1.9.0"
+        "@webassemblyjs/wast-printer": "1.8.5"
       }
     },
     "@webassemblyjs/helper-fsm": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.9.0.tgz",
-      "integrity": "sha512-OPRowhGbshCb5PxJ8LocpdX9Kl0uB4XsAjl6jH/dWKlk/mzsANvhwbiULsaiqT5GZGT9qinTICdj6PLuM5gslw==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.8.5.tgz",
+      "integrity": "sha512-kRuX/saORcg8se/ft6Q2UbRpZwP4y7YrWsLXPbbmtepKr22i8Z4O3V5QE9DbZK908dh5Xya4Un57SDIKwB9eow==",
       "dev": true
     },
     "@webassemblyjs/helper-module-context": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.9.0.tgz",
-      "integrity": "sha512-MJCW8iGC08tMk2enck1aPW+BE5Cw8/7ph/VGZxwyvGbJwjktKkDK7vy7gAmMDx88D7mhDTCNKAW5tED+gZ0W8g==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.8.5.tgz",
+      "integrity": "sha512-/O1B236mN7UNEU4t9X7Pj38i4VoU8CcMHyy3l2cV/kIF4U5KoHXDVqcDuOs1ltkac90IM4vZdHc52t1x8Yfs3g==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.9.0"
+        "@webassemblyjs/ast": "1.8.5",
+        "mamacro": "^0.0.3"
       }
     },
     "@webassemblyjs/helper-wasm-bytecode": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.9.0.tgz",
-      "integrity": "sha512-R7FStIzyNcd7xKxCZH5lE0Bqy+hGTwS3LJjuv1ZVxd9O7eHCedSdrId/hMOd20I+v8wDXEn+bjfKDLzTepoaUw==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.8.5.tgz",
+      "integrity": "sha512-Cu4YMYG3Ddl72CbmpjU/wbP6SACcOPVbHN1dI4VJNJVgFwaKf1ppeFJrwydOG3NDHxVGuCfPlLZNyEdIYlQ6QQ==",
       "dev": true
     },
     "@webassemblyjs/helper-wasm-section": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.9.0.tgz",
-      "integrity": "sha512-XnMB8l3ek4tvrKUUku+IVaXNHz2YsJyOOmz+MMkZvh8h1uSJpSen6vYnw3IoQ7WwEuAhL8Efjms1ZWjqh2agvw==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.8.5.tgz",
+      "integrity": "sha512-VV083zwR+VTrIWWtgIUpqfvVdK4ff38loRmrdDBgBT8ADXYsEZ5mPQ4Nde90N3UYatHdYoDIFb7oHzMncI02tA==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.9.0",
-        "@webassemblyjs/helper-buffer": "1.9.0",
-        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
-        "@webassemblyjs/wasm-gen": "1.9.0"
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/helper-buffer": "1.8.5",
+        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+        "@webassemblyjs/wasm-gen": "1.8.5"
       }
     },
     "@webassemblyjs/ieee754": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.9.0.tgz",
-      "integrity": "sha512-dcX8JuYU/gvymzIHc9DgxTzUUTLexWwt8uCTWP3otys596io0L5aW02Gb1RjYpx2+0Jus1h4ZFqjla7umFniTg==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.8.5.tgz",
+      "integrity": "sha512-aaCvQYrvKbY/n6wKHb/ylAJr27GglahUO89CcGXMItrOBqRarUMxWLJgxm9PJNuKULwN5n1csT9bYoMeZOGF3g==",
       "dev": true,
       "requires": {
         "@xtuc/ieee754": "^1.2.0"
       }
     },
     "@webassemblyjs/leb128": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.9.0.tgz",
-      "integrity": "sha512-ENVzM5VwV1ojs9jam6vPys97B/S65YQtv/aanqnU7D8aSoHFX8GyhGg0CMfyKNIHBuAVjy3tlzd5QMMINa7wpw==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.8.5.tgz",
+      "integrity": "sha512-plYUuUwleLIziknvlP8VpTgO4kqNaH57Y3JnNa6DLpu/sGcP6hbVdfdX5aHAV716pQBKrfuU26BJK29qY37J7A==",
       "dev": true,
       "requires": {
         "@xtuc/long": "4.2.2"
       }
     },
     "@webassemblyjs/utf8": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.9.0.tgz",
-      "integrity": "sha512-GZbQlWtopBTP0u7cHrEx+73yZKrQoBMpwkGEIqlacljhXCkVM1kMQge/Mf+csMJAjEdSwhOyLAS0AoR3AG5P8w==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.8.5.tgz",
+      "integrity": "sha512-U7zgftmQriw37tfD934UNInokz6yTmn29inT2cAetAsaU9YeVCveWEwhKL1Mg4yS7q//NGdzy79nlXh3bT8Kjw==",
       "dev": true
     },
     "@webassemblyjs/wasm-edit": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.9.0.tgz",
-      "integrity": "sha512-FgHzBm80uwz5M8WKnMTn6j/sVbqilPdQXTWraSjBwFXSYGirpkSWE2R9Qvz9tNiTKQvoKILpCuTjBKzOIm0nxw==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.8.5.tgz",
+      "integrity": "sha512-A41EMy8MWw5yvqj7MQzkDjU29K7UJq1VrX2vWLzfpRHt3ISftOXqrtojn7nlPsZ9Ijhp5NwuODuycSvfAO/26Q==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.9.0",
-        "@webassemblyjs/helper-buffer": "1.9.0",
-        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
-        "@webassemblyjs/helper-wasm-section": "1.9.0",
-        "@webassemblyjs/wasm-gen": "1.9.0",
-        "@webassemblyjs/wasm-opt": "1.9.0",
-        "@webassemblyjs/wasm-parser": "1.9.0",
-        "@webassemblyjs/wast-printer": "1.9.0"
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/helper-buffer": "1.8.5",
+        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+        "@webassemblyjs/helper-wasm-section": "1.8.5",
+        "@webassemblyjs/wasm-gen": "1.8.5",
+        "@webassemblyjs/wasm-opt": "1.8.5",
+        "@webassemblyjs/wasm-parser": "1.8.5",
+        "@webassemblyjs/wast-printer": "1.8.5"
       }
     },
     "@webassemblyjs/wasm-gen": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.9.0.tgz",
-      "integrity": "sha512-cPE3o44YzOOHvlsb4+E9qSqjc9Qf9Na1OO/BHFy4OI91XDE14MjFN4lTMezzaIWdPqHnsTodGGNP+iRSYfGkjA==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.8.5.tgz",
+      "integrity": "sha512-BCZBT0LURC0CXDzj5FXSc2FPTsxwp3nWcqXQdOZE4U7h7i8FqtFK5Egia6f9raQLpEKT1VL7zr4r3+QX6zArWg==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.9.0",
-        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
-        "@webassemblyjs/ieee754": "1.9.0",
-        "@webassemblyjs/leb128": "1.9.0",
-        "@webassemblyjs/utf8": "1.9.0"
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+        "@webassemblyjs/ieee754": "1.8.5",
+        "@webassemblyjs/leb128": "1.8.5",
+        "@webassemblyjs/utf8": "1.8.5"
       }
     },
     "@webassemblyjs/wasm-opt": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.9.0.tgz",
-      "integrity": "sha512-Qkjgm6Anhm+OMbIL0iokO7meajkzQD71ioelnfPEj6r4eOFuqm4YC3VBPqXjFyyNwowzbMD+hizmprP/Fwkl2A==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.8.5.tgz",
+      "integrity": "sha512-HKo2mO/Uh9A6ojzu7cjslGaHaUU14LdLbGEKqTR7PBKwT6LdPtLLh9fPY33rmr5wcOMrsWDbbdCHq4hQUdd37Q==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.9.0",
-        "@webassemblyjs/helper-buffer": "1.9.0",
-        "@webassemblyjs/wasm-gen": "1.9.0",
-        "@webassemblyjs/wasm-parser": "1.9.0"
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/helper-buffer": "1.8.5",
+        "@webassemblyjs/wasm-gen": "1.8.5",
+        "@webassemblyjs/wasm-parser": "1.8.5"
       }
     },
     "@webassemblyjs/wasm-parser": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.9.0.tgz",
-      "integrity": "sha512-9+wkMowR2AmdSWQzsPEjFU7njh8HTO5MqO8vjwEHuM+AMHioNqSBONRdr0NQQ3dVQrzp0s8lTcYqzUdb7YgELA==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.8.5.tgz",
+      "integrity": "sha512-pi0SYE9T6tfcMkthwcgCpL0cM9nRYr6/6fjgDtL6q/ZqKHdMWvxitRi5JcZ7RI4SNJJYnYNaWy5UUrHQy998lw==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.9.0",
-        "@webassemblyjs/helper-api-error": "1.9.0",
-        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
-        "@webassemblyjs/ieee754": "1.9.0",
-        "@webassemblyjs/leb128": "1.9.0",
-        "@webassemblyjs/utf8": "1.9.0"
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/helper-api-error": "1.8.5",
+        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+        "@webassemblyjs/ieee754": "1.8.5",
+        "@webassemblyjs/leb128": "1.8.5",
+        "@webassemblyjs/utf8": "1.8.5"
       }
     },
     "@webassemblyjs/wast-parser": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.9.0.tgz",
-      "integrity": "sha512-qsqSAP3QQ3LyZjNC/0jBJ/ToSxfYJ8kYyuiGvtn/8MK89VrNEfwj7BPQzJVHi0jGTRK2dGdJ5PRqhtjzoww+bw==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.8.5.tgz",
+      "integrity": "sha512-daXC1FyKWHF1i11obK086QRlsMsY4+tIOKgBqI1lxAnkp9xe9YMcgOxm9kLe+ttjs5aWV2KKE1TWJCN57/Btsg==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.9.0",
-        "@webassemblyjs/floating-point-hex-parser": "1.9.0",
-        "@webassemblyjs/helper-api-error": "1.9.0",
-        "@webassemblyjs/helper-code-frame": "1.9.0",
-        "@webassemblyjs/helper-fsm": "1.9.0",
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/floating-point-hex-parser": "1.8.5",
+        "@webassemblyjs/helper-api-error": "1.8.5",
+        "@webassemblyjs/helper-code-frame": "1.8.5",
+        "@webassemblyjs/helper-fsm": "1.8.5",
         "@xtuc/long": "4.2.2"
       }
     },
     "@webassemblyjs/wast-printer": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.9.0.tgz",
-      "integrity": "sha512-2J0nE95rHXHyQ24cWjMKJ1tqB/ds8z/cyeOZxJhcb+rW+SQASVjuznUSmdz5GpVJTzU8JkhYut0D3siFDD6wsA==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.8.5.tgz",
+      "integrity": "sha512-w0U0pD4EhlnvRyeJzBqaVSJAo9w/ce7/WPogeXLzGkO6hzhr4GnQIZ4W4uUt5b9ooAaXPtnXlj0gzsXEOUNYMg==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.9.0",
-        "@webassemblyjs/wast-parser": "1.9.0",
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/wast-parser": "1.8.5",
         "@xtuc/long": "4.2.2"
       }
     },
@@ -3091,9 +3092,9 @@
       },
       "dependencies": {
         "bn.js": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+          "version": "4.11.9",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
           "dev": true
         }
       }
@@ -3446,9 +3447,9 @@
       "dev": true
     },
     "bn.js": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.1.tgz",
-      "integrity": "sha512-IUTD/REb78Z2eodka1QZyyEk66pciRcP6Sroka0aI3tG/iwIdYLrBD62RsubR7vqdt3WyX8p4jxeatzmRSphtA==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.2.tgz",
+      "integrity": "sha512-40rZaf3bUNKTVYu9sIeeEGOg7g14Yvnj9kH7b50EiwX0Q7A6umbvfI5tvHaOERH0XigqKkfLkFQxzb4e6CIXnA==",
       "dev": true
     },
     "body-parser": {
@@ -3599,9 +3600,9 @@
       },
       "dependencies": {
         "bn.js": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+          "version": "4.11.9",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
           "dev": true
         }
       }
@@ -4513,9 +4514,9 @@
       },
       "dependencies": {
         "bn.js": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+          "version": "4.11.9",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
           "dev": true
         }
       }
@@ -4863,9 +4864,9 @@
       },
       "dependencies": {
         "bn.js": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+          "version": "4.11.9",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
           "dev": true
         }
       }
@@ -5082,9 +5083,9 @@
       },
       "dependencies": {
         "bn.js": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+          "version": "4.11.9",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
           "dev": true
         }
       }
@@ -7869,6 +7870,12 @@
         "semver": "^5.6.0"
       }
     },
+    "mamacro": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/mamacro/-/mamacro-0.0.3.tgz",
+      "integrity": "sha512-qMEwh+UujcQ+kbz3T6V+wAmO2U8veoq2w+3wY8MquqwVA3jChfwY+Tk52GZKDfACEPjuZ7r2oJLejwpt8jtwTA==",
+      "dev": true
+    },
     "map-age-cleaner": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
@@ -8215,9 +8222,9 @@
       },
       "dependencies": {
         "bn.js": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+          "version": "4.11.9",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
           "dev": true
         }
       }
@@ -9662,9 +9669,9 @@
       },
       "dependencies": {
         "bn.js": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+          "version": "4.11.9",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
           "dev": true
         }
       }
@@ -12633,16 +12640,16 @@
       }
     },
     "webpack": {
-      "version": "4.43.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.43.0.tgz",
-      "integrity": "sha512-GW1LjnPipFW2Y78OOab8NJlCflB7EFskMih2AHdvjbpKMeDJqEgSx24cXXXiPS65+WSwVyxtDsJH6jGX2czy+g==",
+      "version": "4.40.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.40.1.tgz",
+      "integrity": "sha512-AAP7F9X1cVNnQl0ZsG52qF89tqCKS8lqVEnFOA0g/G25/VyH4CejwTbSD9aEDGStAIuH+l6W1yOYRZNOP0VE1g==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.9.0",
-        "@webassemblyjs/helper-module-context": "1.9.0",
-        "@webassemblyjs/wasm-edit": "1.9.0",
-        "@webassemblyjs/wasm-parser": "1.9.0",
-        "acorn": "^6.4.1",
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/helper-module-context": "1.8.5",
+        "@webassemblyjs/wasm-edit": "1.8.5",
+        "@webassemblyjs/wasm-parser": "1.8.5",
+        "acorn": "^6.2.1",
         "ajv": "^6.10.2",
         "ajv-keywords": "^3.4.1",
         "chrome-trace-event": "^1.0.2",
@@ -12653,13 +12660,13 @@
         "loader-utils": "^1.2.3",
         "memory-fs": "^0.4.1",
         "micromatch": "^3.1.10",
-        "mkdirp": "^0.5.3",
+        "mkdirp": "^0.5.1",
         "neo-async": "^2.6.1",
         "node-libs-browser": "^2.2.1",
         "schema-utils": "^1.0.0",
         "tapable": "^1.1.3",
-        "terser-webpack-plugin": "^1.4.3",
-        "watchpack": "^1.6.1",
+        "terser-webpack-plugin": "^1.4.1",
+        "watchpack": "^1.6.0",
         "webpack-sources": "^1.4.1"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "vue-loader": "^15.7.1",
     "vue-style-loader": "^4.1.2",
     "vue-template-compiler": "^2.6.10",
-    "webpack": "^4.40.2",
+    "webpack": "^4.40.1",
     "webpack-cli": "^3.3.9",
     "webpack-dev-server": "^3.8.1",
     "webpack-merge": "^4.2.2"

--- a/src/graphql/mutations.js
+++ b/src/graphql/mutations.js
@@ -14,7 +14,6 @@ export const createEnquiry = `mutation CreateEnquiry(
     languageIndex
     type
     warriorId
-    warriorName
     table
     owner
     responses {
@@ -28,7 +27,6 @@ export const createEnquiry = `mutation CreateEnquiry(
         languageIndex
         enquiryId
         warriorId
-        warriorName
         table
         owner
       }
@@ -70,7 +68,6 @@ export const updateEnquiry = `mutation UpdateEnquiry(
     languageIndex
     type
     warriorId
-    warriorName
     table
     owner
     responses {
@@ -84,7 +81,6 @@ export const updateEnquiry = `mutation UpdateEnquiry(
         languageIndex
         enquiryId
         warriorId
-        warriorName
         table
         owner
       }
@@ -126,7 +122,6 @@ export const deleteEnquiry = `mutation DeleteEnquiry(
     languageIndex
     type
     warriorId
-    warriorName
     table
     owner
     responses {
@@ -140,7 +135,6 @@ export const deleteEnquiry = `mutation DeleteEnquiry(
         languageIndex
         enquiryId
         warriorId
-        warriorName
         table
         owner
       }
@@ -183,7 +177,6 @@ export const createResponse = `mutation CreateResponse(
     languageIndex
     enquiryId
     warriorId
-    warriorName
     table
     enquiry {
       id
@@ -194,7 +187,6 @@ export const createResponse = `mutation CreateResponse(
       languageIndex
       type
       warriorId
-      warriorName
       table
       owner
       responses {
@@ -217,7 +209,6 @@ export const createResponse = `mutation CreateResponse(
       items {
         responseId
         warriorId
-        warriorName
         url
         owner
       }
@@ -260,7 +251,6 @@ export const updateResponse = `mutation UpdateResponse(
     languageIndex
     enquiryId
     warriorId
-    warriorName
     table
     enquiry {
       id
@@ -271,7 +261,6 @@ export const updateResponse = `mutation UpdateResponse(
       languageIndex
       type
       warriorId
-      warriorName
       table
       owner
       responses {
@@ -294,7 +283,6 @@ export const updateResponse = `mutation UpdateResponse(
       items {
         responseId
         warriorId
-        warriorName
         url
         owner
       }
@@ -337,7 +325,6 @@ export const deleteResponse = `mutation DeleteResponse(
     languageIndex
     enquiryId
     warriorId
-    warriorName
     table
     enquiry {
       id
@@ -348,7 +335,6 @@ export const deleteResponse = `mutation DeleteResponse(
       languageIndex
       type
       warriorId
-      warriorName
       table
       owner
       responses {
@@ -371,7 +357,6 @@ export const deleteResponse = `mutation DeleteResponse(
       items {
         responseId
         warriorId
-        warriorName
         url
         owner
       }
@@ -407,7 +392,6 @@ export const createMedia = `mutation CreateMedia(
   createMedia(input: $input, condition: $condition) {
     responseId
     warriorId
-    warriorName
     url
     response {
       id
@@ -419,7 +403,6 @@ export const createMedia = `mutation CreateMedia(
       languageIndex
       enquiryId
       warriorId
-      warriorName
       table
       enquiry {
         id
@@ -430,7 +413,6 @@ export const createMedia = `mutation CreateMedia(
         languageIndex
         type
         warriorId
-        warriorName
         table
         owner
       }
@@ -481,7 +463,6 @@ export const updateMedia = `mutation UpdateMedia(
   updateMedia(input: $input, condition: $condition) {
     responseId
     warriorId
-    warriorName
     url
     response {
       id
@@ -493,7 +474,6 @@ export const updateMedia = `mutation UpdateMedia(
       languageIndex
       enquiryId
       warriorId
-      warriorName
       table
       enquiry {
         id
@@ -504,7 +484,6 @@ export const updateMedia = `mutation UpdateMedia(
         languageIndex
         type
         warriorId
-        warriorName
         table
         owner
       }
@@ -555,7 +534,6 @@ export const deleteMedia = `mutation DeleteMedia(
   deleteMedia(input: $input, condition: $condition) {
     responseId
     warriorId
-    warriorName
     url
     response {
       id
@@ -567,7 +545,6 @@ export const deleteMedia = `mutation DeleteMedia(
       languageIndex
       enquiryId
       warriorId
-      warriorName
       table
       enquiry {
         id
@@ -578,7 +555,6 @@ export const deleteMedia = `mutation DeleteMedia(
         languageIndex
         type
         warriorId
-        warriorName
         table
         owner
       }
@@ -645,7 +621,6 @@ export const createWarrior = `mutation CreateWarrior(
         languageIndex
         type
         warriorId
-        warriorName
         table
         owner
       }
@@ -662,7 +637,6 @@ export const createWarrior = `mutation CreateWarrior(
         languageIndex
         enquiryId
         warriorId
-        warriorName
         table
         owner
       }
@@ -672,7 +646,6 @@ export const createWarrior = `mutation CreateWarrior(
       items {
         responseId
         warriorId
-        warriorName
         url
         owner
       }
@@ -705,7 +678,6 @@ export const updateWarrior = `mutation UpdateWarrior(
         languageIndex
         type
         warriorId
-        warriorName
         table
         owner
       }
@@ -722,7 +694,6 @@ export const updateWarrior = `mutation UpdateWarrior(
         languageIndex
         enquiryId
         warriorId
-        warriorName
         table
         owner
       }
@@ -732,7 +703,6 @@ export const updateWarrior = `mutation UpdateWarrior(
       items {
         responseId
         warriorId
-        warriorName
         url
         owner
       }
@@ -765,7 +735,6 @@ export const deleteWarrior = `mutation DeleteWarrior(
         languageIndex
         type
         warriorId
-        warriorName
         table
         owner
       }
@@ -782,7 +751,6 @@ export const deleteWarrior = `mutation DeleteWarrior(
         languageIndex
         enquiryId
         warriorId
-        warriorName
         table
         owner
       }
@@ -792,7 +760,6 @@ export const deleteWarrior = `mutation DeleteWarrior(
       items {
         responseId
         warriorId
-        warriorName
         url
         owner
       }

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -11,7 +11,6 @@ export const getEnquiry = `query GetEnquiry($id: ID!) {
     languageIndex
     type
     warriorId
-    warriorName
     table
     owner
     responses {
@@ -25,7 +24,6 @@ export const getEnquiry = `query GetEnquiry($id: ID!) {
         languageIndex
         enquiryId
         warriorId
-        warriorName
         table
         owner
       }
@@ -69,7 +67,6 @@ export const listEnquirys = `query ListEnquirys(
       languageIndex
       type
       warriorId
-      warriorName
       table
       owner
       responses {
@@ -116,7 +113,6 @@ export const byEnquiryCreatedAt = `query ByEnquiryCreatedAt(
       languageIndex
       type
       warriorId
-      warriorName
       table
       owner
       responses {
@@ -163,7 +159,6 @@ export const byEnquiryUpdatedAt = `query ByEnquiryUpdatedAt(
       languageIndex
       type
       warriorId
-      warriorName
       table
       owner
       responses {
@@ -208,7 +203,6 @@ export const enquiryByWarrior = `query EnquiryByWarrior(
       languageIndex
       type
       warriorId
-      warriorName
       table
       owner
       responses {
@@ -241,7 +235,6 @@ export const getResponse = `query GetResponse($id: ID!) {
     languageIndex
     enquiryId
     warriorId
-    warriorName
     table
     enquiry {
       id
@@ -252,7 +245,6 @@ export const getResponse = `query GetResponse($id: ID!) {
       languageIndex
       type
       warriorId
-      warriorName
       table
       owner
       responses {
@@ -275,7 +267,6 @@ export const getResponse = `query GetResponse($id: ID!) {
       items {
         responseId
         warriorId
-        warriorName
         url
         owner
       }
@@ -320,7 +311,6 @@ export const listResponses = `query ListResponses(
       languageIndex
       enquiryId
       warriorId
-      warriorName
       table
       enquiry {
         id
@@ -331,7 +321,6 @@ export const listResponses = `query ListResponses(
         languageIndex
         type
         warriorId
-        warriorName
         table
         owner
       }
@@ -381,7 +370,6 @@ export const byResponseCreatedAt = `query ByResponseCreatedAt(
       languageIndex
       enquiryId
       warriorId
-      warriorName
       table
       enquiry {
         id
@@ -392,7 +380,6 @@ export const byResponseCreatedAt = `query ByResponseCreatedAt(
         languageIndex
         type
         warriorId
-        warriorName
         table
         owner
       }
@@ -442,7 +429,6 @@ export const byResponseUpdatedAt = `query ByResponseUpdatedAt(
       languageIndex
       enquiryId
       warriorId
-      warriorName
       table
       enquiry {
         id
@@ -453,7 +439,6 @@ export const byResponseUpdatedAt = `query ByResponseUpdatedAt(
         languageIndex
         type
         warriorId
-        warriorName
         table
         owner
       }
@@ -501,7 +486,6 @@ export const responseByEnquiry = `query ResponseByEnquiry(
       languageIndex
       enquiryId
       warriorId
-      warriorName
       table
       enquiry {
         id
@@ -512,7 +496,6 @@ export const responseByEnquiry = `query ResponseByEnquiry(
         languageIndex
         type
         warriorId
-        warriorName
         table
         owner
       }
@@ -560,7 +543,6 @@ export const responseByWarrior = `query ResponseByWarrior(
       languageIndex
       enquiryId
       warriorId
-      warriorName
       table
       enquiry {
         id
@@ -571,7 +553,6 @@ export const responseByWarrior = `query ResponseByWarrior(
         languageIndex
         type
         warriorId
-        warriorName
         table
         owner
       }
@@ -599,7 +580,6 @@ export const getMedia = `query GetMedia($id: ID!) {
   getMedia(id: $id) {
     responseId
     warriorId
-    warriorName
     url
     response {
       id
@@ -611,7 +591,6 @@ export const getMedia = `query GetMedia($id: ID!) {
       languageIndex
       enquiryId
       warriorId
-      warriorName
       table
       enquiry {
         id
@@ -622,7 +601,6 @@ export const getMedia = `query GetMedia($id: ID!) {
         languageIndex
         type
         warriorId
-        warriorName
         table
         owner
       }
@@ -675,7 +653,6 @@ export const listMedias = `query ListMedias(
     items {
       responseId
       warriorId
-      warriorName
       url
       response {
         id
@@ -687,7 +664,6 @@ export const listMedias = `query ListMedias(
         languageIndex
         enquiryId
         warriorId
-        warriorName
         table
         owner
       }
@@ -725,7 +701,6 @@ export const mediaByResponse = `query MediaByResponse(
     items {
       responseId
       warriorId
-      warriorName
       url
       response {
         id
@@ -737,7 +712,6 @@ export const mediaByResponse = `query MediaByResponse(
         languageIndex
         enquiryId
         warriorId
-        warriorName
         table
         owner
       }
@@ -775,7 +749,6 @@ export const mediaByWarrior = `query MediaByWarrior(
     items {
       responseId
       warriorId
-      warriorName
       url
       response {
         id
@@ -787,7 +760,6 @@ export const mediaByWarrior = `query MediaByWarrior(
         languageIndex
         enquiryId
         warriorId
-        warriorName
         table
         owner
       }
@@ -866,7 +838,6 @@ export const getWarrior = `query GetWarrior($id: ID!) {
         languageIndex
         type
         warriorId
-        warriorName
         table
         owner
       }
@@ -883,7 +854,6 @@ export const getWarrior = `query GetWarrior($id: ID!) {
         languageIndex
         enquiryId
         warriorId
-        warriorName
         table
         owner
       }
@@ -893,7 +863,6 @@ export const getWarrior = `query GetWarrior($id: ID!) {
       items {
         responseId
         warriorId
-        warriorName
         url
         owner
       }

--- a/src/graphql/schema.json
+++ b/src/graphql/schema.json
@@ -1094,9 +1094,13 @@
           "description" : null,
           "args" : [ ],
           "type" : {
-            "kind" : "OBJECT",
-            "name" : "Warrior",
-            "ofType" : null
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "OBJECT",
+              "name" : "Warrior",
+              "ofType" : null
+            }
           },
           "isDeprecated" : false,
           "deprecationReason" : null
@@ -1379,9 +1383,13 @@
           "description" : null,
           "args" : [ ],
           "type" : {
-            "kind" : "OBJECT",
-            "name" : "Enquiry",
-            "ofType" : null
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "OBJECT",
+              "name" : "Enquiry",
+              "ofType" : null
+            }
           },
           "isDeprecated" : false,
           "deprecationReason" : null
@@ -1448,9 +1456,13 @@
           "description" : null,
           "args" : [ ],
           "type" : {
-            "kind" : "OBJECT",
-            "name" : "Warrior",
-            "ofType" : null
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "OBJECT",
+              "name" : "Warrior",
+              "ofType" : null
+            }
           },
           "isDeprecated" : false,
           "deprecationReason" : null
@@ -1577,9 +1589,13 @@
           "description" : null,
           "args" : [ ],
           "type" : {
-            "kind" : "OBJECT",
-            "name" : "Response",
-            "ofType" : null
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "OBJECT",
+              "name" : "Response",
+              "ofType" : null
+            }
           },
           "isDeprecated" : false,
           "deprecationReason" : null
@@ -1599,9 +1615,13 @@
           "description" : null,
           "args" : [ ],
           "type" : {
-            "kind" : "OBJECT",
-            "name" : "Warrior",
-            "ofType" : null
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "OBJECT",
+              "name" : "Warrior",
+              "ofType" : null
+            }
           },
           "isDeprecated" : false,
           "deprecationReason" : null
@@ -5987,14 +6007,6 @@
         "onFragment" : false,
         "onField" : true
       }, {
-        "name" : "aws_api_key",
-        "description" : "Tells the service this field/object has access authorized by an API key.",
-        "locations" : [ "OBJECT", "FIELD_DEFINITION" ],
-        "args" : [ ],
-        "onOperation" : false,
-        "onFragment" : false,
-        "onField" : false
-      }, {
         "name" : "aws_publish",
         "description" : "Tells the service which subscriptions will be published to when this mutation is called. This directive is deprecated use @aws_susbscribe directive instead.",
         "locations" : [ "FIELD_DEFINITION" ],
@@ -6019,27 +6031,6 @@
         "name" : "aws_auth",
         "description" : "Directs the schema to enforce authorization on a field",
         "locations" : [ "FIELD_DEFINITION" ],
-        "args" : [ {
-          "name" : "cognito_groups",
-          "description" : "List of cognito user pool groups which have access on this field",
-          "type" : {
-            "kind" : "LIST",
-            "name" : null,
-            "ofType" : {
-              "kind" : "SCALAR",
-              "name" : "String",
-              "ofType" : null
-            }
-          },
-          "defaultValue" : null
-        } ],
-        "onOperation" : false,
-        "onFragment" : false,
-        "onField" : false
-      }, {
-        "name" : "aws_cognito_user_pools",
-        "description" : "Tells the service this field/object has access authorized by a Cognito User Pools token.",
-        "locations" : [ "OBJECT", "FIELD_DEFINITION" ],
         "args" : [ {
           "name" : "cognito_groups",
           "description" : "List of cognito user pool groups which have access on this field",
@@ -6083,14 +6074,6 @@
         "onFragment" : false,
         "onField" : false
       }, {
-        "name" : "aws_iam",
-        "description" : "Tells the service this field/object has access authorized by sigv4 signing.",
-        "locations" : [ "OBJECT", "FIELD_DEFINITION" ],
-        "args" : [ ],
-        "onOperation" : false,
-        "onFragment" : false,
-        "onField" : false
-      }, {
         "name" : "aws_subscribe",
         "description" : "Tells the service which mutation triggers this subscription.",
         "locations" : [ "FIELD_DEFINITION" ],
@@ -6108,6 +6091,43 @@
           },
           "defaultValue" : null
         } ],
+        "onOperation" : false,
+        "onFragment" : false,
+        "onField" : false
+      }, {
+        "name" : "aws_iam",
+        "description" : "Tells the service this field/object has access authorized by sigv4 signing.",
+        "locations" : [ "OBJECT", "FIELD_DEFINITION" ],
+        "args" : [ ],
+        "onOperation" : false,
+        "onFragment" : false,
+        "onField" : false
+      }, {
+        "name" : "aws_cognito_user_pools",
+        "description" : "Tells the service this field/object has access authorized by a Cognito User Pools token.",
+        "locations" : [ "OBJECT", "FIELD_DEFINITION" ],
+        "args" : [ {
+          "name" : "cognito_groups",
+          "description" : "List of cognito user pool groups which have access on this field",
+          "type" : {
+            "kind" : "LIST",
+            "name" : null,
+            "ofType" : {
+              "kind" : "SCALAR",
+              "name" : "String",
+              "ofType" : null
+            }
+          },
+          "defaultValue" : null
+        } ],
+        "onOperation" : false,
+        "onFragment" : false,
+        "onField" : false
+      }, {
+        "name" : "aws_api_key",
+        "description" : "Tells the service this field/object has access authorized by an API key.",
+        "locations" : [ "OBJECT", "FIELD_DEFINITION" ],
+        "args" : [ ],
         "onOperation" : false,
         "onFragment" : false,
         "onField" : false

--- a/src/graphql/schema.json
+++ b/src/graphql/schema.json
@@ -1002,21 +1002,6 @@
           "isDeprecated" : false,
           "deprecationReason" : null
         }, {
-          "name" : "warriorName",
-          "description" : null,
-          "args" : [ ],
-          "type" : {
-            "kind" : "NON_NULL",
-            "name" : null,
-            "ofType" : {
-              "kind" : "SCALAR",
-              "name" : "String",
-              "ofType" : null
-            }
-          },
-          "isDeprecated" : false,
-          "deprecationReason" : null
-        }, {
           "name" : "table",
           "description" : null,
           "args" : [ ],
@@ -1349,21 +1334,6 @@
           "isDeprecated" : false,
           "deprecationReason" : null
         }, {
-          "name" : "warriorName",
-          "description" : null,
-          "args" : [ ],
-          "type" : {
-            "kind" : "NON_NULL",
-            "name" : null,
-            "ofType" : {
-              "kind" : "SCALAR",
-              "name" : "String",
-              "ofType" : null
-            }
-          },
-          "isDeprecated" : false,
-          "deprecationReason" : null
-        }, {
           "name" : "table",
           "description" : null,
           "args" : [ ],
@@ -1549,21 +1519,6 @@
             "ofType" : {
               "kind" : "SCALAR",
               "name" : "ID",
-              "ofType" : null
-            }
-          },
-          "isDeprecated" : false,
-          "deprecationReason" : null
-        }, {
-          "name" : "warriorName",
-          "description" : null,
-          "args" : [ ],
-          "type" : {
-            "kind" : "NON_NULL",
-            "name" : null,
-            "ofType" : {
-              "kind" : "SCALAR",
-              "name" : "String",
               "ofType" : null
             }
           },
@@ -2013,15 +1968,6 @@
           "type" : {
             "kind" : "INPUT_OBJECT",
             "name" : "ModelIDInput",
-            "ofType" : null
-          },
-          "defaultValue" : null
-        }, {
-          "name" : "warriorName",
-          "description" : null,
-          "type" : {
-            "kind" : "INPUT_OBJECT",
-            "name" : "ModelStringInput",
             "ofType" : null
           },
           "defaultValue" : null
@@ -2637,15 +2583,6 @@
           },
           "defaultValue" : null
         }, {
-          "name" : "warriorName",
-          "description" : null,
-          "type" : {
-            "kind" : "INPUT_OBJECT",
-            "name" : "ModelStringInput",
-            "ofType" : null
-          },
-          "defaultValue" : null
-        }, {
           "name" : "table",
           "description" : null,
           "type" : {
@@ -2740,15 +2677,6 @@
           "type" : {
             "kind" : "INPUT_OBJECT",
             "name" : "ModelIDInput",
-            "ofType" : null
-          },
-          "defaultValue" : null
-        }, {
-          "name" : "warriorName",
-          "description" : null,
-          "type" : {
-            "kind" : "INPUT_OBJECT",
-            "name" : "ModelStringInput",
             "ofType" : null
           },
           "defaultValue" : null
@@ -3579,19 +3507,6 @@
           },
           "defaultValue" : null
         }, {
-          "name" : "warriorName",
-          "description" : null,
-          "type" : {
-            "kind" : "NON_NULL",
-            "name" : null,
-            "ofType" : {
-              "kind" : "SCALAR",
-              "name" : "String",
-              "ofType" : null
-            }
-          },
-          "defaultValue" : null
-        }, {
           "name" : "table",
           "description" : null,
           "type" : {
@@ -3673,15 +3588,6 @@
           "type" : {
             "kind" : "INPUT_OBJECT",
             "name" : "ModelIDInput",
-            "ofType" : null
-          },
-          "defaultValue" : null
-        }, {
-          "name" : "warriorName",
-          "description" : null,
-          "type" : {
-            "kind" : "INPUT_OBJECT",
-            "name" : "ModelStringInput",
             "ofType" : null
           },
           "defaultValue" : null
@@ -3811,15 +3717,6 @@
           "type" : {
             "kind" : "SCALAR",
             "name" : "ID",
-            "ofType" : null
-          },
-          "defaultValue" : null
-        }, {
-          "name" : "warriorName",
-          "description" : null,
-          "type" : {
-            "kind" : "SCALAR",
-            "name" : "String",
             "ofType" : null
           },
           "defaultValue" : null
@@ -3969,19 +3866,6 @@
           },
           "defaultValue" : null
         }, {
-          "name" : "warriorName",
-          "description" : null,
-          "type" : {
-            "kind" : "NON_NULL",
-            "name" : null,
-            "ofType" : {
-              "kind" : "SCALAR",
-              "name" : "String",
-              "ofType" : null
-            }
-          },
-          "defaultValue" : null
-        }, {
           "name" : "table",
           "description" : null,
           "type" : {
@@ -4072,15 +3956,6 @@
           "type" : {
             "kind" : "INPUT_OBJECT",
             "name" : "ModelIDInput",
-            "ofType" : null
-          },
-          "defaultValue" : null
-        }, {
-          "name" : "warriorName",
-          "description" : null,
-          "type" : {
-            "kind" : "INPUT_OBJECT",
-            "name" : "ModelStringInput",
             "ofType" : null
           },
           "defaultValue" : null
@@ -4223,15 +4098,6 @@
           },
           "defaultValue" : null
         }, {
-          "name" : "warriorName",
-          "description" : null,
-          "type" : {
-            "kind" : "SCALAR",
-            "name" : "String",
-            "ofType" : null
-          },
-          "defaultValue" : null
-        }, {
           "name" : "table",
           "description" : null,
           "type" : {
@@ -4294,19 +4160,6 @@
           },
           "defaultValue" : null
         }, {
-          "name" : "warriorName",
-          "description" : null,
-          "type" : {
-            "kind" : "NON_NULL",
-            "name" : null,
-            "ofType" : {
-              "kind" : "SCALAR",
-              "name" : "String",
-              "ofType" : null
-            }
-          },
-          "defaultValue" : null
-        }, {
           "name" : "url",
           "description" : null,
           "type" : {
@@ -4343,15 +4196,6 @@
           "type" : {
             "kind" : "INPUT_OBJECT",
             "name" : "ModelIDInput",
-            "ofType" : null
-          },
-          "defaultValue" : null
-        }, {
-          "name" : "warriorName",
-          "description" : null,
-          "type" : {
-            "kind" : "INPUT_OBJECT",
-            "name" : "ModelStringInput",
             "ofType" : null
           },
           "defaultValue" : null
@@ -4423,15 +4267,6 @@
           "type" : {
             "kind" : "SCALAR",
             "name" : "ID",
-            "ofType" : null
-          },
-          "defaultValue" : null
-        }, {
-          "name" : "warriorName",
-          "description" : null,
-          "type" : {
-            "kind" : "SCALAR",
-            "name" : "String",
             "ofType" : null
           },
           "defaultValue" : null
@@ -5028,6 +4863,100 @@
         "possibleTypes" : null
       }, {
         "kind" : "INPUT_OBJECT",
+        "name" : "ModelIntInput",
+        "description" : null,
+        "fields" : null,
+        "inputFields" : [ {
+          "name" : "ne",
+          "description" : null,
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "Int",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "eq",
+          "description" : null,
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "Int",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "le",
+          "description" : null,
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "Int",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "lt",
+          "description" : null,
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "Int",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "ge",
+          "description" : null,
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "Int",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "gt",
+          "description" : null,
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "Int",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "between",
+          "description" : null,
+          "type" : {
+            "kind" : "LIST",
+            "name" : null,
+            "ofType" : {
+              "kind" : "SCALAR",
+              "name" : "Int",
+              "ofType" : null
+            }
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "attributeExists",
+          "description" : null,
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "Boolean",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "attributeType",
+          "description" : null,
+          "type" : {
+            "kind" : "ENUM",
+            "name" : "ModelAttributeTypes",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        } ],
+        "interfaces" : null,
+        "enumValues" : null,
+        "possibleTypes" : null
+      }, {
+        "kind" : "INPUT_OBJECT",
         "name" : "ModelFloatInput",
         "description" : null,
         "fields" : null,
@@ -5126,100 +5055,6 @@
         "description" : "Built-in Float",
         "fields" : null,
         "inputFields" : null,
-        "interfaces" : null,
-        "enumValues" : null,
-        "possibleTypes" : null
-      }, {
-        "kind" : "INPUT_OBJECT",
-        "name" : "ModelIntInput",
-        "description" : null,
-        "fields" : null,
-        "inputFields" : [ {
-          "name" : "ne",
-          "description" : null,
-          "type" : {
-            "kind" : "SCALAR",
-            "name" : "Int",
-            "ofType" : null
-          },
-          "defaultValue" : null
-        }, {
-          "name" : "eq",
-          "description" : null,
-          "type" : {
-            "kind" : "SCALAR",
-            "name" : "Int",
-            "ofType" : null
-          },
-          "defaultValue" : null
-        }, {
-          "name" : "le",
-          "description" : null,
-          "type" : {
-            "kind" : "SCALAR",
-            "name" : "Int",
-            "ofType" : null
-          },
-          "defaultValue" : null
-        }, {
-          "name" : "lt",
-          "description" : null,
-          "type" : {
-            "kind" : "SCALAR",
-            "name" : "Int",
-            "ofType" : null
-          },
-          "defaultValue" : null
-        }, {
-          "name" : "ge",
-          "description" : null,
-          "type" : {
-            "kind" : "SCALAR",
-            "name" : "Int",
-            "ofType" : null
-          },
-          "defaultValue" : null
-        }, {
-          "name" : "gt",
-          "description" : null,
-          "type" : {
-            "kind" : "SCALAR",
-            "name" : "Int",
-            "ofType" : null
-          },
-          "defaultValue" : null
-        }, {
-          "name" : "between",
-          "description" : null,
-          "type" : {
-            "kind" : "LIST",
-            "name" : null,
-            "ofType" : {
-              "kind" : "SCALAR",
-              "name" : "Int",
-              "ofType" : null
-            }
-          },
-          "defaultValue" : null
-        }, {
-          "name" : "attributeExists",
-          "description" : null,
-          "type" : {
-            "kind" : "SCALAR",
-            "name" : "Boolean",
-            "ofType" : null
-          },
-          "defaultValue" : null
-        }, {
-          "name" : "attributeType",
-          "description" : null,
-          "type" : {
-            "kind" : "ENUM",
-            "name" : "ModelAttributeTypes",
-            "ofType" : null
-          },
-          "defaultValue" : null
-        } ],
         "interfaces" : null,
         "enumValues" : null,
         "possibleTypes" : null
@@ -6057,23 +5892,6 @@
         "onFragment" : false,
         "onField" : false
       }, {
-        "name" : "deprecated",
-        "description" : null,
-        "locations" : [ "FIELD_DEFINITION", "ENUM_VALUE" ],
-        "args" : [ {
-          "name" : "reason",
-          "description" : null,
-          "type" : {
-            "kind" : "SCALAR",
-            "name" : "String",
-            "ofType" : null
-          },
-          "defaultValue" : "\"No longer supported\""
-        } ],
-        "onOperation" : false,
-        "onFragment" : false,
-        "onField" : false
-      }, {
         "name" : "aws_subscribe",
         "description" : "Tells the service which mutation triggers this subscription.",
         "locations" : [ "FIELD_DEFINITION" ],
@@ -6099,6 +5917,23 @@
         "description" : "Tells the service this field/object has access authorized by sigv4 signing.",
         "locations" : [ "OBJECT", "FIELD_DEFINITION" ],
         "args" : [ ],
+        "onOperation" : false,
+        "onFragment" : false,
+        "onField" : false
+      }, {
+        "name" : "deprecated",
+        "description" : null,
+        "locations" : [ "FIELD_DEFINITION", "ENUM_VALUE" ],
+        "args" : [ {
+          "name" : "reason",
+          "description" : null,
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "String",
+            "ofType" : null
+          },
+          "defaultValue" : "\"No longer supported\""
+        } ],
         "onOperation" : false,
         "onFragment" : false,
         "onField" : false

--- a/src/graphql/subscriptions.js
+++ b/src/graphql/subscriptions.js
@@ -11,7 +11,6 @@ export const onCreateEnquiry = `subscription OnCreateEnquiry($owner: String) {
     languageIndex
     type
     warriorId
-    warriorName
     table
     owner
     responses {
@@ -25,7 +24,6 @@ export const onCreateEnquiry = `subscription OnCreateEnquiry($owner: String) {
         languageIndex
         enquiryId
         warriorId
-        warriorName
         table
         owner
       }
@@ -64,7 +62,6 @@ export const onUpdateEnquiry = `subscription OnUpdateEnquiry($owner: String) {
     languageIndex
     type
     warriorId
-    warriorName
     table
     owner
     responses {
@@ -78,7 +75,6 @@ export const onUpdateEnquiry = `subscription OnUpdateEnquiry($owner: String) {
         languageIndex
         enquiryId
         warriorId
-        warriorName
         table
         owner
       }
@@ -117,7 +113,6 @@ export const onDeleteEnquiry = `subscription OnDeleteEnquiry($owner: String) {
     languageIndex
     type
     warriorId
-    warriorName
     table
     owner
     responses {
@@ -131,7 +126,6 @@ export const onDeleteEnquiry = `subscription OnDeleteEnquiry($owner: String) {
         languageIndex
         enquiryId
         warriorId
-        warriorName
         table
         owner
       }
@@ -171,7 +165,6 @@ export const onCreateResponse = `subscription OnCreateResponse($owner: String) {
     languageIndex
     enquiryId
     warriorId
-    warriorName
     table
     enquiry {
       id
@@ -182,7 +175,6 @@ export const onCreateResponse = `subscription OnCreateResponse($owner: String) {
       languageIndex
       type
       warriorId
-      warriorName
       table
       owner
       responses {
@@ -205,7 +197,6 @@ export const onCreateResponse = `subscription OnCreateResponse($owner: String) {
       items {
         responseId
         warriorId
-        warriorName
         url
         owner
       }
@@ -245,7 +236,6 @@ export const onUpdateResponse = `subscription OnUpdateResponse($owner: String) {
     languageIndex
     enquiryId
     warriorId
-    warriorName
     table
     enquiry {
       id
@@ -256,7 +246,6 @@ export const onUpdateResponse = `subscription OnUpdateResponse($owner: String) {
       languageIndex
       type
       warriorId
-      warriorName
       table
       owner
       responses {
@@ -279,7 +268,6 @@ export const onUpdateResponse = `subscription OnUpdateResponse($owner: String) {
       items {
         responseId
         warriorId
-        warriorName
         url
         owner
       }
@@ -319,7 +307,6 @@ export const onDeleteResponse = `subscription OnDeleteResponse($owner: String) {
     languageIndex
     enquiryId
     warriorId
-    warriorName
     table
     enquiry {
       id
@@ -330,7 +317,6 @@ export const onDeleteResponse = `subscription OnDeleteResponse($owner: String) {
       languageIndex
       type
       warriorId
-      warriorName
       table
       owner
       responses {
@@ -353,7 +339,6 @@ export const onDeleteResponse = `subscription OnDeleteResponse($owner: String) {
       items {
         responseId
         warriorId
-        warriorName
         url
         owner
       }
@@ -386,7 +371,6 @@ export const onCreateMedia = `subscription OnCreateMedia($owner: String) {
   onCreateMedia(owner: $owner) {
     responseId
     warriorId
-    warriorName
     url
     response {
       id
@@ -398,7 +382,6 @@ export const onCreateMedia = `subscription OnCreateMedia($owner: String) {
       languageIndex
       enquiryId
       warriorId
-      warriorName
       table
       enquiry {
         id
@@ -409,7 +392,6 @@ export const onCreateMedia = `subscription OnCreateMedia($owner: String) {
         languageIndex
         type
         warriorId
-        warriorName
         table
         owner
       }
@@ -457,7 +439,6 @@ export const onUpdateMedia = `subscription OnUpdateMedia($owner: String) {
   onUpdateMedia(owner: $owner) {
     responseId
     warriorId
-    warriorName
     url
     response {
       id
@@ -469,7 +450,6 @@ export const onUpdateMedia = `subscription OnUpdateMedia($owner: String) {
       languageIndex
       enquiryId
       warriorId
-      warriorName
       table
       enquiry {
         id
@@ -480,7 +460,6 @@ export const onUpdateMedia = `subscription OnUpdateMedia($owner: String) {
         languageIndex
         type
         warriorId
-        warriorName
         table
         owner
       }
@@ -528,7 +507,6 @@ export const onDeleteMedia = `subscription OnDeleteMedia($owner: String) {
   onDeleteMedia(owner: $owner) {
     responseId
     warriorId
-    warriorName
     url
     response {
       id
@@ -540,7 +518,6 @@ export const onDeleteMedia = `subscription OnDeleteMedia($owner: String) {
       languageIndex
       enquiryId
       warriorId
-      warriorName
       table
       enquiry {
         id
@@ -551,7 +528,6 @@ export const onDeleteMedia = `subscription OnDeleteMedia($owner: String) {
         languageIndex
         type
         warriorId
-        warriorName
         table
         owner
       }
@@ -615,7 +591,6 @@ export const onCreateWarrior = `subscription OnCreateWarrior($owner: String) {
         languageIndex
         type
         warriorId
-        warriorName
         table
         owner
       }
@@ -632,7 +607,6 @@ export const onCreateWarrior = `subscription OnCreateWarrior($owner: String) {
         languageIndex
         enquiryId
         warriorId
-        warriorName
         table
         owner
       }
@@ -642,7 +616,6 @@ export const onCreateWarrior = `subscription OnCreateWarrior($owner: String) {
       items {
         responseId
         warriorId
-        warriorName
         url
         owner
       }
@@ -672,7 +645,6 @@ export const onUpdateWarrior = `subscription OnUpdateWarrior($owner: String) {
         languageIndex
         type
         warriorId
-        warriorName
         table
         owner
       }
@@ -689,7 +661,6 @@ export const onUpdateWarrior = `subscription OnUpdateWarrior($owner: String) {
         languageIndex
         enquiryId
         warriorId
-        warriorName
         table
         owner
       }
@@ -699,7 +670,6 @@ export const onUpdateWarrior = `subscription OnUpdateWarrior($owner: String) {
       items {
         responseId
         warriorId
-        warriorName
         url
         owner
       }
@@ -729,7 +699,6 @@ export const onDeleteWarrior = `subscription OnDeleteWarrior($owner: String) {
         languageIndex
         type
         warriorId
-        warriorName
         table
         owner
       }
@@ -746,7 +715,6 @@ export const onDeleteWarrior = `subscription OnDeleteWarrior($owner: String) {
         languageIndex
         enquiryId
         warriorId
-        warriorName
         table
         owner
       }
@@ -756,7 +724,6 @@ export const onDeleteWarrior = `subscription OnDeleteWarrior($owner: String) {
       items {
         responseId
         warriorId
-        warriorName
         url
         owner
       }

--- a/src/pages/new-enquiry.vue
+++ b/src/pages/new-enquiry.vue
@@ -34,12 +34,10 @@ export default {
   methods: {
     ...mapActions(['createEnquiry']),
     async onSubmit() {
-      console.log('the phrase', this.phrase)
       this.$f7.dialog.preloader('Creating phrase...')
       const enquiry = await this.createEnquiry(this.phrase)
       this.$f7.dialog.close()
-      console.log('got new enquiry', enquiry)
-      this.$f7router.navigate('/detail/')
+      this.$f7router.navigate(`/detail/${enquiry.id}`)
     },
   },
 }

--- a/src/pages/signin.vue
+++ b/src/pages/signin.vue
@@ -66,6 +66,7 @@ export default {
       }
     })
   },
+
   methods: {
     ...mapActions([
       'getUser',

--- a/src/services/client.js
+++ b/src/services/client.js
@@ -1,21 +1,20 @@
 import { API } from 'aws-amplify'
 import { Auth } from '@aws-amplify/auth'
 
+const AuthModes = {
+  Cognito: 'AMAZON_COGNITO_USER_POOLS',
+  Iam: 'AWS_IAM',
+}
+
 export default {
   async request(query, variables) {
-    // NOTE: we intentionally go around the store here
-    let user = null
-    let authMode = 'AMAZON_COGNITO_USER_POOLS'
+    // check to see if we have a session to determine how we authenticate with the API
+    let authMode = AuthModes.Cognito
     try {
-      user = await Auth.currentAuthenticatedUser({ bypassCache: false })
+      await Auth.currentAuthenticatedUser({ bypassCache: false })
     } catch (error) {
-      // no user
+      authMode = AuthModes.Iam
     }
-    if (!user) {
-      // AWS_IAM will allow for public: read as per the graphql schema
-      authMode = 'AWS_IAM'
-    }
-    console.log('Client query authMode', authMode)
 
     return API.graphql({ query, variables, authMode })
   },

--- a/src/services/client.js
+++ b/src/services/client.js
@@ -4,12 +4,18 @@ import { Auth } from '@aws-amplify/auth'
 export default {
   async request(query, variables) {
     // NOTE: we intentionally go around the store here
-    const user = await Auth.currentAuthenticatedUser({ bypassCache: false })
+    let user = null
     let authMode = 'AMAZON_COGNITO_USER_POOLS'
+    try {
+      user = await Auth.currentAuthenticatedUser({ bypassCache: false })
+    } catch (error) {
+      // no user
+    }
     if (!user) {
       // AWS_IAM will allow for public: read as per the graphql schema
       authMode = 'AWS_IAM'
     }
+    console.log('Client query authMode', authMode)
 
     return API.graphql({ query, variables, authMode })
   },

--- a/src/services/client.js
+++ b/src/services/client.js
@@ -11,8 +11,7 @@ export default {
     // check to see if we have a session to determine how we authenticate with the API
     let authMode = AuthModes.Cognito
     try {
-      const user = await Auth.currentAuthenticatedUser({ bypassCache: false })
-      console.log('user', user)
+      await Auth.currentAuthenticatedUser({ bypassCache: false })
     } catch (error) {
       authMode = AuthModes.Iam
     }

--- a/src/services/client.js
+++ b/src/services/client.js
@@ -11,7 +11,8 @@ export default {
     // check to see if we have a session to determine how we authenticate with the API
     let authMode = AuthModes.Cognito
     try {
-      await Auth.currentAuthenticatedUser({ bypassCache: false })
+      const user = await Auth.currentAuthenticatedUser({ bypassCache: false })
+      console.log('user', user)
     } catch (error) {
       authMode = AuthModes.Iam
     }

--- a/src/services/enquiryService.js
+++ b/src/services/enquiryService.js
@@ -5,18 +5,6 @@ import userService from './userService'
 import * as queries from '../graphql/queries'
 import * as mutations from '../graphql/mutations'
 
-/** ENTRY
-createdAt: "2020-05-19T06:47:08.841Z"
-extra: null
-id: (...)
-languageIndex: "todo"
-owner: "f44b835a-01c4-4654-b4dd-5de9ca58acfd"
-responses: Object
-table: "enquiry"
-text: "From my phone"
-type: "phrase"
-updatedAt: "2020-05-19T06:47:08.841Z"
- */
 
 class Response {
   constructor(data) {
@@ -25,7 +13,8 @@ class Response {
     this.type = data.type
     this.createdAt = new Date(data.createdAt)
     this.updatedAt = new Date(data.updatedAt)
-    this.warriorName = data.warriorName
+    this.warriorId = data.warriorId
+    // this.warrior = data.warrior // TODO
     // this.media
   }
 }
@@ -42,14 +31,13 @@ class Enquiry {
     if (data.responses) {
       this.responses = data.responses.items.map((item) => new Response(item))
     }
-    this.warriorName = data.warriorName
+    this.warrior = data.warrior
   }
 }
 
 export default {
   async create(phrase) {
     const user = await userService.get()
-    console.log('user', user)
 
     const id = uuidv1()
     const input = {
@@ -60,14 +48,10 @@ export default {
       languageIndex: 'todo',
       type: 'phrase',
       table: 'enquiry',
-      warriorName: user.name,
       warriorId: user.email,
     }
-
     const response = await client.request(mutations.createEnquiry, { input })
-
-    // TODO: unwrap this
-    return response.data.createEnquiry
+    return new Enquiry(response.data.createEnquiry)
   },
 
   async get(id) {
@@ -84,6 +68,7 @@ export default {
       sortDirection: 'DESC',
     })
 
+    // TODO: unwrap this
     return response.data.byEnquiryUpdatedAt.items
   },
 }

--- a/src/services/enquiryService.js
+++ b/src/services/enquiryService.js
@@ -65,7 +65,7 @@ export default {
     }
 
     const response = await client.request(mutations.createEnquiry, { input })
-    console.log('got enquiry', response)
+
     // TODO: unwrap this
     return response.data.createEnquiry
   },

--- a/src/services/responseService.js
+++ b/src/services/responseService.js
@@ -1,13 +1,16 @@
 import { v1 as uuidv1 } from 'uuid'
 
 import client from './client'
+import userService from './userService'
 
 import * as mutations from '../graphql/mutations'
-// import * as queries from '../graphql/queries'
+import * as queries from '../graphql/queries'
 
 export default {
 
   async create(data) {
+    const user = await userService.get()
+
     const id = uuidv1()
     const input = {
       id,
@@ -18,7 +21,7 @@ export default {
       type: 'phrase',
       table: 'response',
       enquiryId: data.enquiryId,
-      warriorId: '1234',
+      warriorId: user.email,
     }
 
     const response = await client.request(mutations.createResponse, { input })
@@ -30,4 +33,11 @@ export default {
   //   const response = await client.request(queries.getResponse)
   //   return response.data
   // },
+
+  async byEnquiry(enquiryId) {
+    const response = await client.request(queries.responseByEnquiry, { enquiryId })
+    console.log('responses', response)
+    // TODO: unwrap this
+    return response.data.responseByEnquiry.items
+  },
 }

--- a/webpack/dev_helpers/device_router.html
+++ b/webpack/dev_helpers/device_router.html
@@ -1,170 +1,174 @@
 <!DOCTYPE html>
 <html>
+
 <head>
-    <meta charset="utf-8">
-    <meta name="viewport"
-          content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no, minimal-ui">
-    <meta name="apple-mobile-web-app-capable" content="yes">
-    <meta name="apple-mobile-web-app-status-bar-style" content="black">
-    <title>Device Router</title>
+  <meta charset="utf-8">
+  <meta name="viewport"
+    content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no, minimal-ui">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black">
+  <title>Device Router</title>
 
-    <style>
-        html {
-            background: #DDD;
-            font-size: 14px;
-            color: #222;
-            font-family: Arial, sans-serif;
-        }
+  <style>
+    html {
+      background: #DDD;
+      font-size: 14px;
+      color: #222;
+      font-family: Arial, sans-serif;
+    }
 
-        html, body {
-            padding: 0;
-            margin: 0;
-        }
+    html,
+    body {
+      padding: 0;
+      margin: 0;
+    }
 
-        html * {
-            box-sizing: border-box;
-        }
+    html * {
+      box-sizing: border-box;
+    }
 
-        #unavailable {
-            display: block;
-        }
+    #unavailable {
+      display: block;
+    }
 
-        #unavailable p {
-            display: none;
-            font-size: 15px;
-            background: #444;
-            color: #FFF;
-            padding: 20px;
-            margin: 10px;
-            border-radius: 10px;
-            line-height: 24px;
-        }
+    #unavailable p {
+      display: none;
+      font-size: 15px;
+      background: #444;
+      color: #FFF;
+      padding: 20px;
+      margin: 10px;
+      border-radius: 10px;
+      line-height: 24px;
+    }
 
-        #status_text {
-            display: block;
+    #status_text {
+      display: block;
 
-            background: #2196F3;
-            color: #FFF;
-            padding: 20px;
-            margin: 10px;
+      background: #2196F3;
+      color: #FFF;
+      padding: 20px;
+      margin: 10px;
 
-            -webkit-border-radius: 10px;
-            -moz-border-radius: 10px;
-            border-radius: 10px;
-        }
+      -webkit-border-radius: 10px;
+      -moz-border-radius: 10px;
+      border-radius: 10px;
+    }
 
-        input {
-            display: block;
-            background: #FFF;
-            border: 1px solid #CCCCCC;
-            font-size: 14px;
-            color: #222;
-            width: 100%;
-            height: 46px;
-            padding: 10px;
-        }
+    input {
+      display: block;
+      background: #FFF;
+      border: 1px solid #CCCCCC;
+      font-size: 14px;
+      color: #222;
+      width: 100%;
+      height: 46px;
+      padding: 10px;
+    }
 
-        button {
-            display: block;
-            margin-top: 10px;
-            width: 100%;
-            height: 34px;
-        }
+    button {
+      display: block;
+      margin-top: 10px;
+      width: 100%;
+      height: 34px;
+    }
 
-        .input_wrap {
-            padding: 0 10px;
-        }
-    </style>
+    .input_wrap {
+      padding: 0 10px;
+    }
+  </style>
 
 </head>
+
 <body>
 
-<div id="unavailable">
+  <div id="unavailable">
     <p>
-        It seems we can't connect to<br>127.0.0.1:8081<br>
-        <script>document.write(localServerIp)</script>
-        :8081<br><br>
-        You can test yourself with next inputs:
+      It seems we can't connect to<br>127.0.0.1:8081<br>
+      <script>document.write(localServerIp)</script>
+      :8081<br><br>
+      You can test yourself with next inputs:
     </p>
 
     <div id="status_text">
-        Waiting for device ready...
+      Waiting for device ready...
     </div>
 
     <div class="input_wrap">
-        <input type="text" placeholder="Server Ip:Port (like 192.168.0.2:8081)" disabled>
+      <input type="text" placeholder="Server Ip:Port (like 192.168.0.2:8081)" disabled>
     </div>
 
     <div class="input_wrap">
-        <button type="button" onclick="tryConnect()" disabled>Connect</button>
+      <button type="button" onclick="tryConnect()" disabled>Connect</button>
     </div>
-</div>
+  </div>
 
-<script>
+  <script>
     var deviceReadyChecker = setTimeout(startRedirectChecks, 5000);
 
     document.addEventListener("deviceready", function () {
-        clearTimeout(deviceReadyChecker);
+      clearTimeout(deviceReadyChecker);
 
-        if (typeof navigator.splashscreen !== "undefined" && typeof navigator.splashscreen.hide === "function")
-            navigator.splashscreen.hide();
+      if (typeof navigator.splashscreen !== "undefined" && typeof navigator.splashscreen.hide === "function")
+        navigator.splashscreen.hide();
 
-        startRedirectChecks();
+      startRedirectChecks();
     });
 
     function startRedirectChecks() {
-        testConnection('127.0.0.1:8081', goUrl, function () {
-            testConnection(localServerIp + ':8081', goUrl, ajaxErr)
-        })
+      testConnection(localServerIp + ':8081', goUrl, ajaxErr)
+      // testConnection('127.0.0.1:8081', goUrl, function () {
+      // })
     }
 
     function tryConnect() {
-        var ipTest = /^([0-9]{1,3}\.){3}[0-9]{1,3}(:[0-9]{1,6})?$/,
-            ipPort = document.querySelector("input").value;
+      var ipTest = /^([0-9]{1,3}\.){3}[0-9]{1,3}(:[0-9]{1,6})?$/,
+        ipPort = document.querySelector("input").value;
 
-        if (ipTest.test(ipPort))
-            testConnection(ipPort, goUrl, ajaxErr);
+      if (ipTest.test(ipPort))
+        testConnection(ipPort, goUrl, ajaxErr);
     }
 
     function testConnection(ipPort, callback, errCallback) {
-        var xhr = new XMLHttpRequest();
+      var xhr = new XMLHttpRequest();
 
-        document.querySelector("button").disabled = true;
-        document.querySelector("input").disabled = true;
-        document.querySelector("#status_text").innerText = "Trying to connect http://" + ipPort;
+      document.querySelector("button").disabled = true;
+      document.querySelector("input").disabled = true;
+      document.querySelector("#status_text").innerText = "Trying to connect http://" + ipPort;
 
-        xhr.onreadystatechange = function () {
-            if (xhr.readyState === 4 && xhr.status === 200) {
-                document.querySelector("#status_text").innerText = "Connection to 'http://" + ipPort + "/' success! Redirecting...";
+      xhr.onreadystatechange = function () {
+        if (xhr.readyState === 4 && xhr.status === 200) {
+          document.querySelector("#status_text").innerText = "Connection to 'http://" + ipPort + "/' success! Redirecting...";
 
-                if (typeof callback === "function")
-                    callback(ipPort);
-            }
-            else if (xhr.readyState === 4 && xhr.status !== 200) {
-                document.querySelector("button").disabled = false;
-                document.querySelector("input").disabled = false;
-                document.querySelector("#status_text").innerText = "Connection to 'http://" + ipPort + "/' failed!";
-
-                if (typeof errCallback === "function")
-                    errCallback(ipPort);
-            }
+          if (typeof callback === "function")
+            callback(ipPort);
         }
+        else if (xhr.readyState === 4 && xhr.status !== 200) {
+          document.querySelector("button").disabled = false;
+          document.querySelector("input").disabled = false;
+          document.querySelector("#status_text").innerText = "Connection to 'http://" + ipPort + "/' failed!";
 
-        xhr.open('GET', 'http://' + ipPort + '/');
-        xhr.send(null);
+          if (typeof errCallback === "function")
+            errCallback(ipPort);
+        }
+      }
+
+      xhr.open('GET', 'http://' + ipPort + '/');
+      xhr.send(null);
     }
 
     function goUrl(ipPort) {
-        setTimeout(function () {
-            window.location.href = 'http://' + ipPort + '/'
-        }, 1500);
+      setTimeout(function () {
+        window.location.href = 'http://' + ipPort + '/'
+      }, 1500);
     }
 
     function ajaxErr(ipPort) {
-        document.querySelector("#unavailable p").style.display = "block";
-        console.log('Can\'t connect to http://' + ipPort + '/');
+      document.querySelector("#unavailable p").style.display = "block";
+      console.log('Can\'t connect to http://' + ipPort + '/');
     }
 
-</script>
+  </script>
 </body>
+
 </html>


### PR DESCRIPTION
Some changes:

 * tried downgrading webpack to fix sourcemaps, but I realize now what the issue is (more on this below)
 * adjusted `services.client` user check to catch error (and cleaned up)
 * fixed local server hook thing to *not* redirect to 127.0.0.1. I'd still like to rip more of this out later
 * added constraints to content creation _requiring_ `warrior` to be present when querying data
 * adjust the way enquiry detail is loaded (by querying responses) to get full warrior details
 * tweaked the detail view to show responses
 * some cleanup

As for sourcemaps, they actually _work_ when the WDS fires up for the first time, but when it hot-reloads, then they get all screwed up with the warning of conflicting content. I don't see the sourcemaps (or any files for that matter) on disk when the webpack dev server is running (?) does it maintain that stuff in memory? We can look at it down the road, but good to know you can get sourcemaps every once in a while!